### PR TITLE
Longer default wifi password to meet min requirements (8 chars)

### DIFF
--- a/src/Config.h
+++ b/src/Config.h
@@ -24,7 +24,7 @@ void load_factory_default()
   wifiSSID           = "";
   wifiPassword       = "";
   ssidSoftAP         = String("Pedalino-") + getChipId();
-  passwordSoftAP     = getChipId();
+  passwordSoftAP     = getChipId() + getChipId();
   theme              = "bootstrap";
   currentProfile     = 0;
   pressTime          = PED_PRESS_TIME;
@@ -245,7 +245,7 @@ void eeprom_update_sta_wifi_credentials(String ssid = "", String pass = "")
   DPRINT("[NVS][Global][STA Password]: %s\n", pass.c_str());
 }
 
-void eeprom_update_ap_wifi_credentials(String ssid = String("Pedalino-") + getChipId(), String pass = getChipId())
+void eeprom_update_ap_wifi_credentials(String ssid = String("Pedalino-") + getChipId(), String pass = getChipId() + getChipId())
 {
   DPRINT("Updating NVS ... ");
   preferences.begin("Global", false);

--- a/src/Pedalino.h
+++ b/src/Pedalino.h
@@ -400,7 +400,7 @@ String getChipId() {
 
 String host(getChipId());
 String ssidSoftAP("Pedalino-" + getChipId());
-String passwordSoftAP(getChipId());
+String passwordSoftAP(getChipId() + getChipId());
 
 
 #include <AsyncTCP.h>


### PR DESCRIPTION
WiFiAP now requires 8 characters for the AP passphrase, so the chip ID alone (7 characters) is too short to use as the default AP passphrase.
```
     if(passphrase && (strlen(passphrase) > 0 && strlen(passphrase) < 8)) {
        // fail passphrase too short
        log_e("passphrase too short!");
        return false;
    }
```
Changed the default AP passphrase to repeat the chip ID.  It is now 14 characters, and still predictable based on the chip ID, which is part of the default SSID.
```
void eeprom_update_ap_wifi_credentials(
    String ssid = String("Pedalino-") + getChipId(),
    String pass = getChipId() + getChipId())
```
Serial output:
```
AP Pedalino-ABC1234 started with password ABC1234ABC1234
```