### PR TITLE
Add RGB LED color reordering for WS2812B, add FLIP_SCREEN option

### DIFF
--- a/src/DisplayOLED.h
+++ b/src/DisplayOLED.h
@@ -1092,7 +1092,6 @@ int overlaysCount = sizeof(overlays) / sizeof(OverlayCallback);
 void display_init()
 {
   display.init();
-  display.flipScreenVertically();
   display.setContrast(255);
 
 #ifdef WIFI
@@ -1144,7 +1143,9 @@ void display_init()
   // Initialising the UI will init the display too.
   ui.init();
 
-  display.flipScreenVertically();
+  #if FLIP_SCREEN == 1
+    display.flipScreenVertically();
+  #endif
 }
 
 void display_ui_update_disable()

--- a/src/Pedalino.h
+++ b/src/Pedalino.h
@@ -25,7 +25,8 @@ __________           .___      .__  .__                 _____  .__       .__    
 #define STEPS            10   // number of steps for each sequence
 #define LADDER_STEPS      6   // max number of switches in a resistor ladder
 #define LEDS             10   // number of WS2812B leds (254 max)
-#define LED_RGB_ORDER   RGB   // can be RGB or BRG  
+#define LED_RGB_ORDER   RGB   // can be RGB or GRB
+#define FLIP_SCREEN       1   // 0: native, 1: flip vertically  
 #define SLOTS_ROWS        2
 #define SLOTS_COLS        4
 #define SLOTS             SLOTS_ROWS * SLOTS_COLS

--- a/src/Pedalino.h
+++ b/src/Pedalino.h
@@ -25,6 +25,7 @@ __________           .___      .__  .__                 _____  .__       .__    
 #define STEPS            10   // number of steps for each sequence
 #define LADDER_STEPS      6   // max number of switches in a resistor ladder
 #define LEDS             10   // number of WS2812B leds (254 max)
+#define LED_RGB_ORDER   RGB   // can be RGB or BRG  
 #define SLOTS_ROWS        2
 #define SLOTS_COLS        4
 #define SLOTS             SLOTS_ROWS * SLOTS_COLS

--- a/src/PedalinoMini.cpp
+++ b/src/PedalinoMini.cpp
@@ -292,7 +292,7 @@ void setup()
   eeprom_init_or_erase();
   eeprom_read_global();
 
-  FastLED.addLeds<NEOPIXEL, FASTLEDS_DATA_PIN>(fastleds, LEDS);
+  FastLED.addLeds<WS2812B, FASTLEDS_DATA_PIN, LED_RGB_ORDER>(fastleds, LEDS);
   fill_solid(fastleds, LEDS, CRGB::Black);
   FastLED.show();
   lastColor = CRGB::Black;


### PR DESCRIPTION
Here are two very minor enhancements:
1. Using the WS2812B instead of the NEOPIXEL controller in the fastled template enables the option to configure RGB/GRB ordering. This is necessary depending on the type of LED being used. (And it was necessary for me.)
2. Flipping the display vertically seems like a good idea as this might be necessary depending on the physical layout of the case, plugs, etc. - And it was necessary in my case as well ;-)

