### PR TITLE
Support TTGO ESP32 OLED (G511) board + enhanced battery status display

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,5 +21,5 @@ jobs:
 
     - name: Run PlatformIO build on selected platforms
       run: |
-        pio run -e esp32doit-devkit-v1 -e ttgo-t-eight -e ttgo-t-display -e heltec_wifi_kit_32 -e esp-wrover-kit
-        pio run -t buildfs -e esp32doit-devkit-v1 -e ttgo-t-eight -e ttgo-t-display -e heltec_wifi_kit_32 -e esp-wrover-kit
+        pio run -e esp32doit-devkit-v1 -e ttgo-t-eight -e ttgo-t-display -e heltec_wifi_kit_32 -e esp-wrover-kit -e ttgo-esp32-oled
+        pio run -t buildfs -e esp32doit-devkit-v1 -e ttgo-t-eight -e ttgo-t-display -e heltec_wifi_kit_32 -e esp-wrover-kit -e ttgo-esp32-oled

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,8 @@ jobs:
 
     - name: Run PlatformIO build on selected platforms
       run: |
-        pio run -e esp32doit-devkit-v1 -e ttgo-t-eight -e ttgo-t-display -e heltec_wifi_kit_32 -e esp-wrover-kit
-        pio run -t buildfs -e esp32doit-devkit-v1 -e ttgo-t-eight -e ttgo-t-display -e heltec_wifi_kit_32 -e esp-wrover-kit
+        pio run -e esp32doit-devkit-v1 -e ttgo-t-eight -e ttgo-t-display -e heltec_wifi_kit_32 -e esp-wrover-kit -e ttgo-esp32-oled
+        pio run -t buildfs -e esp32doit-devkit-v1 -e ttgo-t-eight -e ttgo-t-display -e heltec_wifi_kit_32 -e esp-wrover-kit -e ttgo-esp32-oled
 
     - name: Copy binary files
       run: |
@@ -77,6 +77,15 @@ jobs:
         cp ./manifest/template.json ./firmware/esp-wrover-kit/esp-wrover-kit-${{ github.event.inputs.tag }}.json
         sed -i 's/x.y.z/${{ github.event.inputs.tag }}/g' ./firmware/esp-wrover-kit/esp-wrover-kit-${{ github.event.inputs.tag }}.json
         sed -i 's/xxx/esp-wrover-kit/g'                   ./firmware/esp-wrover-kit/esp-wrover-kit-${{ github.event.inputs.tag }}.json
+        rm -rf ./firmware/ttgo-esp32-oled/*
+        echo ${{ github.event.inputs.tag }} > ./firmware/ttgo-esp32-oled/version.txt
+        cp ~/.platformio/packages/framework-arduinoespressif32/tools/sdk/bin/bootloader_dio_40m.bin ./firmware/ttgo-esp32-oled/ttgo-esp32-oled-${{ github.event.inputs.tag }}-bootloader.bin
+        cp .pio/build/ttgo-esp32-oled/partitions.bin  ./firmware/ttgo-esp32-oled/ttgo-esp32-oled-${{ github.event.inputs.tag }}-partitions.bin
+        cp .pio/build/ttgo-esp32-oled/firmware.bin    ./firmware/ttgo-esp32-oled/ttgo-esp32-oled-${{ github.event.inputs.tag }}-firmware.bin
+        cp .pio/build/ttgo-esp32-oled/spiffs.bin      ./firmware/ttgo-esp32-oled/ttgo-esp32-oled-${{ github.event.inputs.tag }}-spiffs.bin
+        cp ./manifest/template.json ./firmware/ttgo-esp32-oled/ttgo-esp32-oled-${{ github.event.inputs.tag }}.json
+        sed -i 's/x.y.z/${{ github.event.inputs.tag }}/g' ./firmware/ttgo-esp32-oled/ttgo-esp32-oled-${{ github.event.inputs.tag }}.json
+        sed -i 's/xxx/ttgo-esp32-oled/g'              ./firmware/ttgo-esp32-oled/ttgo-esp32-oled-${{ github.event.inputs.tag }}.json
 
     - name: Commit and push firmware ${{ github.event.inputs.tag }} files
       run: |

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,5 +1,5 @@
 [platformio]
-default_envs  = esp32dev, esp32doit-devkit-v1, esp32doit-devkit-v1-ble, esp32doit-devkit-v1-wifi, esp-wrover-kit, heltec_wifi_kit_32, ttgo-t-eight, ttgo-t-eight-ble, ttgo-t-eight-wifi, ttgo-t-display
+default_envs  = esp32dev, esp32doit-devkit-v1, esp32doit-devkit-v1-ble, esp32doit-devkit-v1-wifi, esp-wrover-kit, heltec_wifi_kit_32, ttgo-t-eight, ttgo-t-eight-ble, ttgo-t-eight-wifi, ttgo-t-display, ttgo-esp32-oled
 ;workspace_dir = ~/Downloads/PedalinoMini
 
 [common]
@@ -122,6 +122,19 @@ build_flags_ttgo_t_display =
 	-D SMOOTH_FONT
   	-D SPI_FREQUENCY=40000000			;	40 Mhz is the maximum for the ST7789V
 	-D SPI_READ_FREQUENCY=6000000		; 	 6 MHz is the maximum SPI read speed for the ST7789V
+build_flags_ttgo_esp32_oled =
+	-D PLATFORMIO_ENV=$PIOENV
+	-D PEDALINO_MINI
+	-D DEBUG_ESP_PORT=Serial
+	-D CORE_DEBUG_LEVEL=ARDUHAL_LOG_LEVEL_WARN
+	-D BATTERY
+	-D TTGO_ESP32_OLED
+;	-DBOARD_HAS_PSRAM
+;	-mfix-esp32-psram-cache-issue
+	-D NOWPS
+	-D WEBSOCKET
+	-D DIAGNOSTIC
+	-D NOSMARTCONFIG
 
 [env]
 platform 	           = espressif32
@@ -240,3 +253,9 @@ upload_port  = /dev/tty.SLAB_USBtoUART
 ;upload_port  = COM5
 monitor_port = ${env:ttgo-t-display.upload_port}
 ;monitor_port = /dev/tty.SLAB_USBtoUART
+
+[env:ttgo-esp32-oled]
+build_flags  = ${common.build_flags_ttgo_esp32_oled}
+;board_build.partitions = src/partitions_no_ota.csv
+upload_port  = COM6
+monitor_port = ${env:ttgo-esp32-oled.upload_port}

--- a/src/DisplayOLED.h
+++ b/src/DisplayOLED.h
@@ -40,7 +40,16 @@ SH1106Wire                display(OLED_I2C_ADDRESS, OLED_I2C_SDA, OLED_I2C_SCL);
 #include <OLEDDisplayUi.h>
 #define OLED_I2C_ADDRESS  0x3c
 #define OLED_I2C_SDA      SDA
-#define OLED_I2C_SCL      SCL
+#define OLED_I2C_SCL      SDA
+SSD1306Wire               display(OLED_I2C_ADDRESS, OLED_I2C_SDA, OLED_I2C_SCL);
+#endif
+#if defined(TTGO_ESP32_OLED)
+#include <SSD1306Wire.h>
+#include <OLEDDisplayUi.h>
+#define OLED_I2C_ADDRESS  0x3c
+#define OLED_I2C_SDA      4
+#define OLED_I2C_SCL      15
+#define OLED_I2C_RST      16
 SSD1306Wire               display(OLED_I2C_ADDRESS, OLED_I2C_SDA, OLED_I2C_SCL);
 #endif
 
@@ -1091,6 +1100,14 @@ int overlaysCount = sizeof(overlays) / sizeof(OverlayCallback);
 
 void display_init()
 {
+
+#if defined(TTGO_ESP32_OLED)
+  pinMode(OLED_I2C_RST,OUTPUT);
+  digitalWrite(OLED_I2C_RST, LOW);   // set OLED_I2C_RST low to reset OLED
+  delay(50);
+  digitalWrite(OLED_I2C_RST, HIGH);  // while OLED is running, must set OLED_I2C_RST in hi
+#endif
+
   display.init();
   display.setContrast(255);
 

--- a/src/DisplayOLED.h
+++ b/src/DisplayOLED.h
@@ -40,7 +40,7 @@ SH1106Wire                display(OLED_I2C_ADDRESS, OLED_I2C_SDA, OLED_I2C_SCL);
 #include <OLEDDisplayUi.h>
 #define OLED_I2C_ADDRESS  0x3c
 #define OLED_I2C_SDA      SDA
-#define OLED_I2C_SCL      SDA
+#define OLED_I2C_SCL      SCL
 SSD1306Wire               display(OLED_I2C_ADDRESS, OLED_I2C_SDA, OLED_I2C_SCL);
 #endif
 #if defined(TTGO_ESP32_OLED)

--- a/src/Pedalino.h
+++ b/src/Pedalino.h
@@ -500,6 +500,7 @@ String wifiPassword("");
 int    wifiLevel = 0;
 
 uint16_t  batteryVoltage = 4200;  // mV
+uint16_t  lastBatteryVoltage = 4200;  // mV
 
 #ifdef DIAGNOSTIC
 #define POINTS                        240             // Logged data points

--- a/src/Pedalino.h
+++ b/src/Pedalino.h
@@ -104,6 +104,10 @@ const byte pinA[] = {GPIO_NUM_36, GPIO_NUM_39, GPIO_NUM_34, GPIO_NUM_35, GPIO_NU
 #define FASTLEDS_DATA_PIN     GPIO_NUM_5
 #endif
 
+#define BATTERY_CHARGING_VOLTAGE    4500
+#define BATTERY_FULL_VOLTAGE        4150
+#define BATTERY_EMPTY_VOLTAGE       3400
+
 #define PIN_D(x)          pinD[x]
 #define PIN_A(x)          pinA[x]
 
@@ -501,6 +505,9 @@ int    wifiLevel = 0;
 
 uint16_t  batteryVoltage = 4200;  // mV
 uint16_t  lastBatteryVoltage = 4200;  // mV
+int       batteryLevel = 100;
+bool      charging = false;
+
 
 #ifdef DIAGNOSTIC
 #define POINTS                        240             // Logged data points

--- a/src/Pedalino.h
+++ b/src/Pedalino.h
@@ -78,6 +78,18 @@ const byte pinA[] = {GPIO_NUM_36, GPIO_NUM_39, GPIO_NUM_34, GPIO_NUM_35, GPIO_NU
 #define DIN_MIDI_OUT_PIN      GPIO_NUM_4
 #define BATTERY_PIN           GPIO_NUM_36   // GPIO_NUM_32 to GPIO_NUM_39 only
 #define FASTLEDS_DATA_PIN     GPIO_NUM_5
+#elif defined TTGO_ESP32_OLED
+#undef  PEDALS
+#define PEDALS                7
+const byte pinD[] = {GPIO_NUM_25, GPIO_NUM_26, GPIO_NUM_27, GPIO_NUM_14, GPIO_NUM_12, GPIO_NUM_13, GPIO_NUM_0};
+const byte pinA[] = {GPIO_NUM_36, GPIO_NUM_39, GPIO_NUM_34, GPIO_NUM_35, GPIO_NUM_32, GPIO_NUM_33, GPIO_NUM_0};
+#define FACTORY_DEFAULT_PIN   GPIO_NUM_0
+#define USB_MIDI_IN_PIN       GPIO_NUM_18
+#define USB_MIDI_OUT_PIN      GPIO_NUM_19
+#define DIN_MIDI_IN_PIN       GPIO_NUM_34
+#define DIN_MIDI_OUT_PIN      GPIO_NUM_35
+#define BATTERY_PIN           GPIO_NUM_32   // GPIO_NUM_32 to GPIO_NUM_39 only
+#define FASTLEDS_DATA_PIN     GPIO_NUM_5
 #else
 #undef  PEDALS
 #define PEDALS                7

--- a/src/PedalinoMini.cpp
+++ b/src/PedalinoMini.cpp
@@ -168,6 +168,32 @@ void wifi_and_battery_level() {
       batteryVoltage = (uint16_t)voltage;
     else
       batteryVoltage = (7 * batteryVoltage + voltage) / 8;
+    // Update charging status and battery level
+    if (batteryVoltage > BATTERY_CHARGING_VOLTAGE) {
+      charging = true;
+      batteryLevel = 100;
+    } else if (batteryVoltage < BATTERY_EMPTY_VOLTAGE) {
+      charging = false;
+      batteryLevel = 10;
+    }
+    else {
+      if(batteryVoltage >= BATTERY_FULL_VOLTAGE) {
+        batteryLevel = 100;
+      } else {
+        // Convert the full / empty voltage range to a 100 % / 10 % battery level range
+        batteryLevel = ((batteryVoltage - BATTERY_EMPTY_VOLTAGE)*90)/(BATTERY_FULL_VOLTAGE-BATTERY_EMPTY_VOLTAGE)+10;
+      }
+      // Battery might be charging in the 2.2 V-> 4.3 V voltage range => let's try and see if voltage is increasing (charging) or decreasing (discharging)
+      int batteryDelta = batteryVoltage - lastBatteryVoltage;
+      // Only track changes > 50mV
+      if((batteryDelta > 50) || (batteryDelta < -50)){
+        // Charging status
+        charging = (batteryDelta > 0);
+        //DPRINT("Current / last  / delta / level / charging : %d / %d / %d / %d / %d\n", batteryVoltage, lastBatteryVoltage, batteryDelta, batteryLevel, charging);
+        lastBatteryVoltage = batteryVoltage;
+      }
+    }
+
 #endif
 
 #ifdef DIAGNOSTIC

--- a/src/PedalinoMini.cpp
+++ b/src/PedalinoMini.cpp
@@ -177,16 +177,16 @@ void wifi_and_battery_level() {
       batteryLevel = 10;
     }
     else {
-      if(batteryVoltage >= BATTERY_FULL_VOLTAGE) {
-        batteryLevel = 100;
-      } else {
-        // Convert the full / empty voltage range to a 100 % / 10 % battery level range
-        batteryLevel = ((batteryVoltage - BATTERY_EMPTY_VOLTAGE)*90)/(BATTERY_FULL_VOLTAGE-BATTERY_EMPTY_VOLTAGE)+10;
-      }
       // Battery might be charging in the 2.2 V-> 4.3 V voltage range => let's try and see if voltage is increasing (charging) or decreasing (discharging)
       int batteryDelta = batteryVoltage - lastBatteryVoltage;
       // Only track changes > 50mV
-      if((batteryDelta > 50) || (batteryDelta < -50)){
+      if(abs(batteryDelta) > 50) {
+        if(batteryVoltage >= BATTERY_FULL_VOLTAGE) {
+          batteryLevel = 100;
+        } else {
+          // Convert the full / empty voltage range to a 100 % / 10 % battery level range
+          batteryLevel = ((batteryVoltage - BATTERY_EMPTY_VOLTAGE)*90)/(BATTERY_FULL_VOLTAGE-BATTERY_EMPTY_VOLTAGE)+10;
+        }
         // Charging status
         charging = (batteryDelta > 0);
         //DPRINT("Current / last  / delta / level / charging : %d / %d / %d / %d / %d\n", batteryVoltage, lastBatteryVoltage, batteryDelta, batteryLevel, charging);

--- a/src/WebConfigAsync.h
+++ b/src/WebConfigAsync.h
@@ -454,7 +454,7 @@ void get_root_page(unsigned int start, unsigned int len) {
   page += freeMemory / 1024;
   page += F(" kB</dd>");
   page += F("<dt>Battery Voltage</dt><dd>");
-  page += String(batteryVoltage / 1000.0, 1);
+  page += String(batteryVoltage / 1000.0, 2);
   page += F(" V ");
   page += batteryVoltage > 4300 ? F("plugged") : F("on battery");
   page += F("</dd>");

--- a/src/WebConfigAsync.h
+++ b/src/WebConfigAsync.h
@@ -455,8 +455,10 @@ void get_root_page(unsigned int start, unsigned int len) {
   page += F(" kB</dd>");
   page += F("<dt>Battery Voltage</dt><dd>");
   page += String(batteryVoltage / 1000.0, 2);
-  page += F(" V ");
-  page += batteryVoltage > 4300 ? F("plugged") : F("on battery");
+  page += F(" V (");
+  page += String(batteryLevel);
+  page += F("%) ");
+  page += charging ? F("plugged") : F("on battery");
   page += F("</dd>");
   //page += F("<dt>Running On Core</dt><dd>");
   //page += xPortGetCoreID();


### PR DESCRIPTION
Hi Alf45tar,

First off thank you for your great work on PedalinoMini !
I'm working on a project based on a TTGO ESP32 OLED board (http://www.lilygo.cn/prod_view.aspx?TypeId=50062&Id=1152&FId=t3:50062:3) to replicate an AirTurn pedal (https://www.airturn.com/products/airturn-bt200s-2-controller) used to control the looper of my Lâg HyVibe guitar.

In case you're interested, this pull request adds support for TTGO ESP32 OLED board.
I also reworked the battery display for a better detection of the charging status with LiPo batteries.

Best regards,

Frederic.