### PR TITLE
Adding Snapshot support

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -11,8 +11,8 @@ build_flags_esp32 =
 	-D DIAGNOSTIC
 	-D NVS
 	;-D BATTERY
-	-D SSD1306WIRE
-;	-D SSH1106WIRE
+;	-D SSD1306WIRE
+	-D SSH1106WIRE
 ;	-D WEBSOCKET
 ;	-D SMARTCONFIG
 ;	-D WPS
@@ -25,8 +25,8 @@ build_flags_esp32-ble =
 	-D DIAGNOSTIC
 	-D NVS
 	-D NOWIFI
-	-D SSD1306WIRE
-;	-D SSH1106WIRE
+;	-D SSD1306WIRE
+	-D SSH1106WIRE
 build_flags_esp32-wifi =
 	-D PLATFORMIO_ENV=$PIOENV
 	-D PEDALINO_MINI
@@ -34,8 +34,8 @@ build_flags_esp32-wifi =
 	-D CORE_DEBUG_LEVEL=ARDUHAL_LOG_LEVEL_WARN
 	-D DIAGNOSTIC
 	-D NOBLE
-	-D SSD1306WIRE
-;	-D SSH1106WIRE
+;	-D SSD1306WIRE
+	-D SSH1106WIRE
 ;	-D WEBSOCKET
 ;	-D NOWEBCONFIG
 ;	-D WPS
@@ -189,29 +189,29 @@ board 		 = esp32doit-devkit-v1
 build_flags  = ${common.build_flags_esp32}
 ;upload_port  = 972de6b4.local
 ;upload_protocol = espota
-upload_port  = /dev/tty.SLAB_USBtoUART
-;upload_port  = COM4
+;upload_port  = /dev/tty.SLAB_USBtoUART
+upload_port  = COM4
 monitor_port = ${env:esp32doit-devkit-v1.upload_port}
 
 [env:esp32doit-devkit-v1-ble]
 board 		 = esp32doit-devkit-v1
 build_flags  = ${common.build_flags_esp32-ble}
-upload_port  = /dev/tty.SLAB_USBtoUART
-;upload_port  = COM4
+;upload_port  = /dev/tty.SLAB_USBtoUART
+upload_port  = COM4
 monitor_port = ${env:esp32doit-devkit-v1-ble.upload_port}
 
 [env:esp32doit-devkit-v1-wifi]
 board 		 = esp32doit-devkit-v1
 build_flags  = ${common.build_flags_esp32-wifi}
-upload_port  = /dev/tty.SLAB_USBtoUART
-;upload_port  = COM4
+;upload_port  = /dev/tty.SLAB_USBtoUART
+upload_port  = COM4
 monitor_port = ${env:esp32doit-devkit-v1-wifi.upload_port}
 
 [env:esp-wrover-kit]
 board 		 = esp-wrover-kit
 build_flags  = ${common.build_flags_esp32}
-upload_port  = /dev/tty.SLAB_USBtoUART
-;upload_port  = COM4
+;upload_port  = /dev/tty.SLAB_USBtoUART
+upload_port  = COM4
 monitor_port = ${env:esp-wrover-kit.upload_port}
 
 [env:heltec_wifi_kit_32]

--- a/src/Config.h
+++ b/src/Config.h
@@ -213,6 +213,9 @@ void spiffs_save_config(const String& filename, bool saveActions = true, bool sa
           case PED_PROGRAM_CHANGE_DEC:
             jo["Message"] = "Program Change-";
             break;
+          case PED_CONTROL_CHANGE_SNAP:
+            jo["Message"] = "Control Change Snap";
+            break;
           case PED_PITCH_BEND:
             jo["Message"] = "Pitch Bend";
             break;
@@ -333,6 +336,9 @@ void spiffs_save_config(const String& filename, bool saveActions = true, bool sa
             break;
           case PED_PROGRAM_CHANGE_INC:
             jo["Message"] = "Program Change+";
+            break;
+          case PED_CONTROL_CHANGE_SNAP:
+            jo["Message"] = "Control Change Snap";
             break;
           case PED_PROGRAM_CHANGE_DEC:
             jo["Message"] = "Program Change-";
@@ -656,6 +662,7 @@ void spiffs_load_config(const String& filename, bool loadActions = true, bool lo
             else if (msg.equals("Bank Select-"))      actions[b]->midiMessage = PED_BANK_SELECT_DEC;
             else if (msg.equals("Program Change+"))   actions[b]->midiMessage = PED_PROGRAM_CHANGE_INC;
             else if (msg.equals("Program Change-"))   actions[b]->midiMessage = PED_PROGRAM_CHANGE_DEC;
+            else if (msg.equals("Control Change Snap"))   actions[b]->midiMessage = PED_CONTROL_CHANGE_SNAP;            
             else if (msg.equals("Pitch Bend"))        actions[b]->midiMessage = PED_PITCH_BEND;
             else if (msg.equals("Channel Pressure"))  actions[b]->midiMessage = PED_CHANNEL_PRESSURE;
             else if (msg.equals("Midi Start"))        actions[b]->midiMessage = PED_MIDI_START;
@@ -721,6 +728,7 @@ void spiffs_load_config(const String& filename, bool loadActions = true, bool lo
                   else if (msg.equals("Bank Select-"))      act->midiMessage = PED_BANK_SELECT_DEC;
                   else if (msg.equals("Program Change+"))   act->midiMessage = PED_PROGRAM_CHANGE_INC;
                   else if (msg.equals("Program Change-"))   act->midiMessage = PED_PROGRAM_CHANGE_DEC;
+                  else if (msg.equals("Control Change Snap"))   act->midiMessage = PED_CONTROL_CHANGE_SNAP;  
                   else if (msg.equals("Pitch Bend"))        act->midiMessage = PED_PITCH_BEND;
                   else if (msg.equals("Channel Pressure"))  act->midiMessage = PED_CHANNEL_PRESSURE;
                   else if (msg.equals("Midi Start"))        act->midiMessage = PED_MIDI_START;
@@ -792,6 +800,7 @@ void spiffs_load_config(const String& filename, bool loadActions = true, bool lo
             else if (msg.equals("Bank Select-"))      sequences[s][t].midiMessage = PED_BANK_SELECT_DEC;
             else if (msg.equals("Program Change+"))   sequences[s][t].midiMessage = PED_PROGRAM_CHANGE_INC;
             else if (msg.equals("Program Change-"))   sequences[s][t].midiMessage = PED_PROGRAM_CHANGE_DEC;
+            else if (msg.equals("Control Change Snap"))   sequences[s][t].midiMessage = PED_CONTROL_CHANGE_SNAP; 
             else if (msg.equals("Pitch Bend"))        sequences[s][t].midiMessage = PED_PITCH_BEND;
             else if (msg.equals("Channel Pressure"))  sequences[s][t].midiMessage = PED_CHANNEL_PRESSURE;
             //else if (msg.equals("Midi Start"))        sequences[s][t].midiMessage = PED_MIDI_START;

--- a/src/Controller.h
+++ b/src/Controller.h
@@ -174,7 +174,7 @@ void leds_update(byte type, byte channel, byte data1, byte data2, byte bank)
             break;
 
           case PED_CONTROL_CHANGE_SNAP:
-          if (type == PED_CONTROL_CHANGE_SNAP) {
+            if (type == PED_CONTROL_CHANGE_SNAP) {
               if ((act->midiCode == data1) && (act->midiValue2 == data2)){
                 lastLedColor[bank][led_button(act->pedal, act->button, act->led)] = act->color1;
                 lastLedColor[bank][led_button(act->pedal, act->button, act->led)].nscale8(ledsOnBrightness);
@@ -579,7 +579,7 @@ void midi_send(byte message, byte code, byte value, byte channel, bool on_off, b
         screen_info(midi::ControlChange, code, value, channel, range_min, range_max);
         currentMIDIValue[bank][pedal][button] = value;
         lastMIDIMessage[currentBank] = {PED_CONTROL_CHANGE, code, value, channel};
-        leds_update(PED_CONTROL_CHANGE_SNAP, channel, code, 0);
+        leds_update(PED_CONTROL_CHANGE_SNAP, channel, code, value);
       }
       break;
 
@@ -1011,9 +1011,12 @@ void controller_run(bool send = true)
       while (act != nullptr) {
         if (act->midiMessage == midi::ControlChange) {
           if (act->tag1[0] != 0 && act->tag1[strlen(act->tag1) - 1] == '.')
-            currentMIDIValue[b][act->pedal][act->button] = act->midiValue2;
+            currentMIDIValue[b][act->pedal][act->button] = act->midiValue2;          
           else
             currentMIDIValue[b][act->pedal][act->button] = act->midiValue1;
+        }
+        if (act->midiMessage == PED_CONTROL_CHANGE_SNAP){      //Added to enable correct initial display of snapshots           
+          currentMIDIValue[b][act->pedal][act->button] = act->midiValue2;
         }
         act = act->next;
       }
@@ -1250,7 +1253,7 @@ void controller_event_handler_button(AceButton* button, uint8_t eventType, uint8
               break;              
               
               
-              case PED_CONTROL_CHANGE:
+            case PED_CONTROL_CHANGE:
 
               if ((pedals[p].mode == PED_MOMENTARY1 ||
                    pedals[p].mode == PED_MOMENTARY2 ||
@@ -1412,7 +1415,7 @@ void controller_event_handler_button(AceButton* button, uint8_t eventType, uint8
               esp_deep_sleep_start();
               break;
           }
-          if (act->midiMessage == PED_PROGRAM_CHANGE) {
+          if (act->midiMessage == PED_PROGRAM_CHANGE||act->midiMessage == PED_CONTROL_CHANGE_SNAP) {
             fastleds[led_button(act->pedal, act->button, act->led)] = act->color1;
             fastleds[led_button(act->pedal, act->button, act->led)].nscale8(ledsOnBrightness);
             fastleds[led_button(act->pedal, act->button, act->led)] = swap_rgb_order(fastleds[led_button(act->pedal, act->button, act->led)], rgbOrder);

--- a/src/DisplayOLED.h
+++ b/src/DisplayOLED.h
@@ -904,6 +904,7 @@ void drawFrame1(OLEDDisplay *display, OLEDDisplayUiState* state, int16_t x, int1
           else
             display->setColor(WHITE);
           display->drawString((128 / (PEDALS / 2 - 1)) * p + offsetText + x, 10 + y, name);
+          display->setColor(WHITE);
           // Bottom line
           name = String((banks[currentBank][p + PEDALS / 2].pedalName[0] == ':') ? &banks[currentBank][p + PEDALS / 2].pedalName[1] : banks[currentBank][p + PEDALS / 2].pedalName);
           name.replace(String("###"), String(currentMIDIValue[currentBank][p + PEDALS / 2][0]));

--- a/src/Pedalino.h
+++ b/src/Pedalino.h
@@ -175,6 +175,7 @@ using namespace ace_button;
 #define PED_BANK_SELECT_DEC           5
 #define PED_PROGRAM_CHANGE_INC        6
 #define PED_PROGRAM_CHANGE_DEC        7
+#define PED_CONTROL_CHANGE_SNAP       8
 #define PED_PITCH_BEND                midi::PitchBend
 #define PED_CHANNEL_PRESSURE          midi::AfterTouchChannel
 #define PED_MIDI_START                midi::Start

--- a/src/WebConfigAsync.h
+++ b/src/WebConfigAsync.h
@@ -4787,6 +4787,7 @@ void http_handle_post_actions(AsyncWebServerRequest *request) {
         act->led          = constrain(request->arg(String("led")        + String(i)).toInt(), 0, 255);
         if (act->led != 255) act->led = (act->led == 0 ? LEDS : constrain(request->arg(String("led") + String(i)).toInt() - 1, 0, LEDS - 1));
         unsigned int red, green, blue;
+        red=0; green=0; blue=0;
         sscanf(                       request->arg(String("color0-")    + String(i)).c_str(), "#%02x%02x%02x", &red, &green, &blue);
         act->color0       = ((red & 0xff) << 16) | ((green & 0xff) << 8) | (blue & 0xff);
         sscanf(                       request->arg(String("color1-")    + String(i)).c_str(), "#%02x%02x%02x", &red, &green, &blue);

--- a/src/WebConfigAsync.h
+++ b/src/WebConfigAsync.h
@@ -1394,6 +1394,11 @@ void get_actions_page(unsigned int start, unsigned int len) {
     if (act->midiMessage == PED_PROGRAM_CHANGE_DEC) page += F(" selected");
     page += F(">Program Change-</option>");
     page += F("<option value='");
+    page += PED_CONTROL_CHANGE_SNAP;
+    page += F("'");
+    if (act->midiMessage == PED_CONTROL_CHANGE_SNAP) page += F(" selected");
+    page += F(">Control Change Snap</option>");
+    page += F("<option value='");
     page += PED_PITCH_BEND;
     page += F("'");
     if (act->midiMessage == PED_PITCH_BEND) page += F(" selected");
@@ -1907,6 +1912,44 @@ void get_actions_page(unsigned int start, unsigned int len) {
             //"           document.getElementById('color0Label'   + i).textContent = 'Color 1';"
             //"           document.getElementById('color1Label'   + i).textContent = 'Color 2';"
             "           break;");
+
+
+  if (trim_page(start, len)) return;
+
+  page += F("         case 'latch':"
+            "           document.getElementById('fromLabel'     + i).textContent = 'Value';"
+            "           document.getElementById('toLabel'       + i).textContent = '';"
+            "           document.getElementById('tagOffLabel'   + i).textContent = 'Tag';"
+            "           document.getElementById('tagOnLabel'    + i).textContent = '';"
+            //"           document.getElementById('color0Label'   + i).textContent = 'Color';"
+            //"           document.getElementById('color1Label'   + i).textContent = '';"
+            "           document.getElementById('toInput'       + i).disabled = true;"
+            "           document.getElementById('tagOnInput'    + i).disabled = true;"
+            //"           document.getElementById('color1Input'   + i).disabled = true;"
+            "           break;"
+            "         case 'analog':"
+            "         case 'jogwheel':"
+            "           document.getElementById('tagOnInput'    + i).disabled = true;"
+            "           break;"
+            "       }"
+            "       break;");
+
+  page += F("     case 'Control Change Snap':"
+            "       document.getElementById('codeLabel'         + i).textContent = 'CC';"
+            "       switch (document.getElementById('pedalMode' + i).value) {"
+            "         case 'momentary':"
+            "         case 'ladder':"
+            "           document.getElementById('fromLabel'     + i).textContent = '';"
+            "           document.getElementById('toLabel'       + i).textContent = 'Value';"
+            "           document.getElementById('tagOffLabel'   + i).textContent = '';"
+            "           document.getElementById('tagOnLabel'    + i).textContent = 'Tag';"
+            //"           document.getElementById('color0Label'   + i).textContent = 'Color 1';"
+            //"           document.getElementById('color1Label'   + i).textContent = 'Color 2';"
+            //"           document.getElementById('codeInput'     + i).disabled = true;"
+            "           document.getElementById('fromInput'   + i).disabled = true;"
+            "           document.getElementById('tagOffInput'   + i).disabled = true;"
+            "           break;");
+
 
   if (trim_page(start, len)) return;
 
@@ -2726,6 +2769,11 @@ void get_sequences_page(unsigned int start, unsigned int len) {
     page += F("'");
     if (sequences[s-1][i-1].midiMessage == PED_PROGRAM_CHANGE_DEC) page += F(" selected");
     page += F(">Program Change-</option>");
+    page += F("<option value='");
+    page += PED_CONTROL_CHANGE_SNAP;
+    page += F("'");
+    if (sequences[s-1][i-1].midiMessage == PED_CONTROL_CHANGE_SNAP) page += F(" selected");
+    page += F(">Control Change Snap</option>");
     page += F("<option value='");
     page += PED_PITCH_BEND;
     page += F("'");


### PR DESCRIPTION
Add a new Action named "Control Change Snap" that sends CC message, but behaves like a Program Change. So there can only be one active at a time per Channel. When engaging one, the rest will disengage.