### PR TITLE
Add ESP32-S3-DevKitC-1 (N16R8) + SSD1306 display support in Behringer FCB1010 case

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,5 +27,5 @@ jobs:
 
     - name: Run PlatformIO build on selected platforms
       run: |
-        pio run -e esp32doit-devkit-v1 -e ttgo-t-eight -e ttgo-t-display -e lilygo-t-display -e heltec_wifi_kit_32 -e esp-wrover-kit -e bpi-leaf-s3 -e lilygo-t-display-s3
-        pio run -t buildfs -e esp32doit-devkit-v1 -e ttgo-t-eight -e ttgo-t-display -e lilygo-t-display -e heltec_wifi_kit_32 -e esp-wrover-kit -e bpi-leaf-s3 -e lilygo-t-display-s3
+        pio run -e esp32doit-devkit-v1 -e ttgo-t-eight -e ttgo-t-display -e lilygo-t-display -e heltec_wifi_kit_32 -e esp-wrover-kit -e bpi-leaf-s3 -e lilygo-t-display-s3 -e esp32-s3-devkitc-1-n16r8v-fcb1010
+        pio run -t buildfs -e esp32doit-devkit-v1 -e ttgo-t-eight -e ttgo-t-display -e lilygo-t-display -e heltec_wifi_kit_32 -e esp-wrover-kit -e bpi-leaf-s3 -e lilygo-t-display-s3 -e esp32-s3-devkitc-1-n16r8v-fcb1010

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -83,8 +83,8 @@ jobs:
 
     - name: Run PlatformIO build on selected platforms
       run: |
-        pio run -e esp32doit-devkit-v1 -e ttgo-t-eight -e ttgo-t-display -e lilygo-t-display -e heltec_wifi_kit_32 -e esp-wrover-kit -e bpi-leaf-s3 -e lilygo-t-display-s3
-        pio run -t buildfs -e esp32doit-devkit-v1 -e ttgo-t-eight -e ttgo-t-display -e lilygo-t-display -e heltec_wifi_kit_32 -e esp-wrover-kit -e bpi-leaf-s3  -e lilygo-t-display-s3
+        pio run -e esp32doit-devkit-v1 -e ttgo-t-eight -e ttgo-t-display -e lilygo-t-display -e heltec_wifi_kit_32 -e esp-wrover-kit -e bpi-leaf-s3 -e lilygo-t-display-s3 -e esp32-s3-devkitc-1-n16r8v-fcb1010
+        pio run -t buildfs -e esp32doit-devkit-v1 -e ttgo-t-eight -e ttgo-t-display -e lilygo-t-display -e heltec_wifi_kit_32 -e esp-wrover-kit -e bpi-leaf-s3 -e lilygo-t-display-s3 -e esp32-s3-devkitc-1-n16r8v-fcb1010
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,8 +32,8 @@ jobs:
 
     - name: Run PlatformIO build on selected platforms
       run: |
-        pio run -e esp32doit-devkit-v1 -e ttgo-t-eight -e ttgo-t-display -e lilygo-t-display -e heltec_wifi_kit_32 -e esp-wrover-kit -e bpi-leaf-s3 -e lilygo-t-display-s3
-        pio run -t buildfs -e esp32doit-devkit-v1 -e ttgo-t-eight -e ttgo-t-display -e lilygo-t-display -e heltec_wifi_kit_32 -e esp-wrover-kit -e bpi-leaf-s3 -e lilygo-t-display-s3
+        pio run -e esp32doit-devkit-v1 -e ttgo-t-eight -e ttgo-t-display -e lilygo-t-display -e heltec_wifi_kit_32 -e esp-wrover-kit -e bpi-leaf-s3 -e lilygo-t-display-s3 -e esp32-s3-devkitc-1-n16r8v-fcb1010
+        pio run -t buildfs -e esp32doit-devkit-v1 -e ttgo-t-eight -e ttgo-t-display -e lilygo-t-display -e heltec_wifi_kit_32 -e esp-wrover-kit -e bpi-leaf-s3 -e lilygo-t-display-s3 -e esp32-s3-devkitc-1-n16r8v-fcb1010
 
     - name: Copy binary files
       run: |
@@ -165,6 +165,22 @@ jobs:
         sed -i 's/x.y.z/${{ github.event.inputs.tag }}/g' ./firmware/lilygo-t-display-s3/lilygo-t-display-s3-${{ github.event.inputs.tag }}.json
         sed -i 's/xxx/lilygo-t-display-s3/g'              ./firmware/lilygo-t-display-s3/lilygo-t-display-s3-${{ github.event.inputs.tag }}.json
         md5sum /tmp/PedalinoMini/build/lilygo-t-display-s3/firmware.bin | head -c 32 > ./firmware/lilygo-t-display-s3/firmware.bin.md5
+        rm -rf ./firmware/esp32-s3-devkitc-1-n16r8v-fcb1010/*
+        echo ${{ github.event.inputs.tag }} > ./firmware/esp32-s3-devkitc-1-n16r8v-fcb1010/version.txt
+        python ~/.platformio/packages/tool-esptoolpy/esptool.py --chip esp32s3 merge_bin \
+                                                                -o ./firmware/esp32-s3-devkitc-1-n16r8v-fcb1010/esp32-s3-devkitc-1-n16r8v-fcb1010-${{ github.event.inputs.tag }}-firmware.bin \
+                                                                --flash_mode dio \
+                                                                --flash_freq 80m \
+                                                                --flash_size 16MB \
+                                                                0x0000 /tmp/PedalinoMini/build/esp32-s3-devkitc-1-n16r8v-fcb1010/bootloader.bin \
+                                                                0x8000 /tmp/PedalinoMini/build/esp32-s3-devkitc-1-n16r8v-fcb1010/partitions.bin \
+                                                                0xe000 ~/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin \
+                                                                0x10000 /tmp/PedalinoMini/build/esp32-s3-devkitc-1-n16r8v-fcb1010/firmware.bin \
+                                                                0x6e0000 /tmp/PedalinoMini/build/esp32-s3-devkitc-1-n16r8v-fcb1010/spiffs.bin
+        cp ./manifest/template_esp32s3.json ./firmware/esp32-s3-devkitc-1-n16r8v-fcb1010/esp32-s3-devkitc-1-n16r8v-fcb1010-${{ github.event.inputs.tag }}.json
+        sed -i 's/x.y.z/${{ github.event.inputs.tag }}/g' ./firmware/esp32-s3-devkitc-1-n16r8v-fcb1010/esp32-s3-devkitc-1-n16r8v-fcb1010-${{ github.event.inputs.tag }}.json
+        sed -i 's/xxx/esp32-s3-devkitc-1-n16r8v-fcb1010/g'         ./firmware/esp32-s3-devkitc-1-n16r8v-fcb1010/esp32-s3-devkitc-1-n16r8v-fcb1010-fcb1010-${{ github.event.inputs.tag }}.json
+        md5sum /tmp/PedalinoMini/build/esp32-s3-devkitc-1-n16r8v-fcb1010/firmware.bin | head -c 32 > ./firmware/esp32-s3-devkitc-1-n16r8v-fcb1010/firmware.bin.md5
 
     - name: Commit and push firmware ${{ github.event.inputs.tag }} files
       run: |

--- a/boards/esp32-s3-devkitc-1-n16r8v.json
+++ b/boards/esp32-s3-devkitc-1-n16r8v.json
@@ -1,0 +1,53 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32s3_out.ld",
+      "partitions": "default_16MB.csv",
+      "memory_type": "qio_opi"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_ESP32S3_DEV",
+      "-DBOARD_HAS_PSRAM",
+      "-DARDUINO_USB_MODE=0",
+      "-DARDUINO_USB_CDC_ON_BOOT=1"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "psram_type": "opi",
+    "hwids": [
+      [
+        "0x303A",
+        "0x1001"
+      ]
+    ],
+    "mcu": "esp32s3",
+    "variant": "esp32s3"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth"
+  ],
+  "debug": {
+    "default_tool": "esp-builtin",
+    "onboard_tools": [
+      "esp-builtin"
+    ],
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "Espressif ESP32-S3-DevKitC-1-N16R8V (16 MB QD, 8MB PSRAM)",
+  "upload": {
+    "flash_size": "16MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 16777216,
+    "require_upload_port": true,
+    "speed": 921600
+  },
+  "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/esp32s3/user-guide-devkitc-1.html",
+  "vendor": "Espressif"
+}

--- a/platformio.ini
+++ b/platformio.ini
@@ -8,7 +8,7 @@
 ;                                                                          https://github.com/alf45tar/PedalinoMini
 
 [platformio]
-default_envs  =	bpi-leaf-s3, lilygo-t-display-s3, lilygo-t-display, ttgo-t-display, esp32dev, esp32doit-devkit-v1, esp32doit-devkit-v1-ble, esp32doit-devkit-v1-wifi, esp-wrover-kit, heltec_wifi_kit_32, ttgo-t-eight, ttgo-t-eight-ble, ttgo-t-eight-wifi
+default_envs  =	esp32-s3-devkitc-1-n16r8v-fcb1010, bpi-leaf-s3, lilygo-t-display-s3, lilygo-t-display, ttgo-t-display, esp32dev, esp32doit-devkit-v1, esp32doit-devkit-v1-ble, esp32doit-devkit-v1-wifi, esp-wrover-kit, heltec_wifi_kit_32, ttgo-t-eight, ttgo-t-eight-ble, ttgo-t-eight-wifi
 workspace_dir = ${sysenv.TMPDIR}/PedalinoMini
 
 [common]
@@ -273,3 +273,16 @@ lib_deps	= 	${common.lib_deps}
 ;debug_speed = 12000
 ;debug_tool = esp-builtin
 ;debug_init_break = tbreak setup
+
+
+; ESP32-S3 Devkit N16 R8 Dual USB C with SSD1306 display - configured for Behringer FCB1010 case
+[env:esp32-s3-devkitc-1-n16r8v-fcb1010]
+platform  	= 	espressif32@6.9.0
+framework 	= 	arduino
+board     	= 	esp32-s3-devkitc-1-n16r8v
+board_build.partitions = src/partitions_esp32-s3-devkitc-1-n16r8v.csv
+build_flags = 	${common.build_flags}
+			  	-D SSD1306WIRE
+lib_deps    = 	${common.lib_deps}
+	          	thingpulse/ESP8266 and ESP32 OLED driver for SSD1306 displays@4.5.0		;	https://github.com/ThingPulse/esp8266-oled-ssd1306
+		      	adafruit/Adafruit TinyUSB Library@3.3.4									;	https://github.com/adafruit/Adafruit_TinyUSB_Arduino

--- a/src/OTAHTTPS.h
+++ b/src/OTAHTTPS.h
@@ -19,6 +19,9 @@ __________           .___      .__  .__                 _____  .__       .__    
 #if defined(ARDUINO_BPI_LEAF_S3) || defined(ARDUINO_LILYGO_T_DISPLAY_S3)
 #define OTA_PARTITION_SIZE    0x360000            // 3538944 bytes
 #define FIRMWARE_MAX_SIZE     (8 * 1024 * 1024)   // 8M
+#elif defined(ARDUINO_ESP32S3_DEV)
+#define OTA_PARTITION_SIZE    0x360000            // 3538944 bytes
+#define FIRMWARE_MAX_SIZE     (16 * 1024 * 1024)  // 16M
 #else
 #define OTA_PARTITION_SIZE    0x1D0000            // 1900544 bytes
 #define FIRMWARE_MAX_SIZE     (4 * 1024 * 1024)   // 4M

--- a/src/Pedalino.h
+++ b/src/Pedalino.h
@@ -126,6 +126,80 @@ const byte pinA[] = {GPIO_NUM_44, GPIO_NUM_43, GPIO_NUM_10, GPIO_NUM_3,  GPIO_NU
 #define DIN_MIDI_OUT_PIN      GPIO_NUM_1
 #define BATTERY_PIN           GPIO_NUM_4    // Pin connected to BAT (BAT is not VBAT)
 #define FASTLEDS_DATA_PIN     GPIO_NUM_21
+#elif defined ARDUINO_ESP32S3_DEV
+/**
+Support for the esp32-s3-devkitc-1-n16r8v board
+
+GND - GND
+3V3 - Logic Level Converter (LV)
+EN - reserved (CHIP_EN)
+4 - ___UNUSED___
+5 - Button 12
+6 - Button 11
+7 - Button 10
+15 - Button 9
+16 - Button 8
+17 - Button 7
+18 - Button 6
+8 - Button 5
+19 - reserved (USB D-)
+20 - reserved (USB D+)
+3 - JTAG Ctrl
+46 - reserved (ROM msg)
+9 - Button 4
+10 - Button 3
+11 - Button 2
+12 - Button 1
+3V3 - ___UNUSED___
+
+GND - GND
+1 - Logic Level Converter Channel 1 - MIDI Out (TX)
+2 - Logic Level Converter Channel 2 - MIDI In (RX)
+TX0 - reserved (used for flashing)
+RX0 - reserved (used for flashing)
+42 - WS2812B Data In
+41 - SDA for OLED I2C 0.96"/1.3" display 128x64 pixels SSD1306/SH1106 based display
+40 - SCL for OLED I2C 0.96"/1.3" display 128x64 pixels SSD1306/SH1106 based display
+39 - ___UNUSED___
+38 - ___UNUSED___
+37 - reserved (PSRAM)
+36 - reserved (PSRAM)
+35 - reserved (PSRAM)
+0 - reserved (FW DL)
+45 - reserved (VDD_SPI)
+48 - ___UNUSED___
+47 - ___UNUSED___
+21 -___UNUSED___
+14 - Voltage Divider - Expression pedal 1 (left)
+13 - Voltage Divider - Expression pedal 2 (right)
+VIN - 5V
+ */
+#undef  PEDALS
+#define PEDALS        14 // Pedal 1-10, up/down pedals, expression pedal
+#undef  LEDS
+#define LEDS          23 // Pedal 1-10, expression pedal 1+2, 11 config LEDs
+#undef  SLOTS_ROWS
+#define SLOTS_ROWS    2
+#undef  SLOTS_COLS
+#define SLOTS_COLS    7
+#define SLOTS         SLOTS_ROWS * SLOTS_COLS
+/*
+Digital inputs: GPIO_NUM_12, GPIO_NUM_11, GPIO_NUM_10, GPIO_NUM_9,  GPIO_NUM_8,  GPIO_NUM_18, GPIO_NUM_17, GPIO_NUM_16, GPIO_NUM_15, GPIO_NUM_7,  GPIO_NUM_6,  GPIO_NUM_5
+Analog inputs: GPIO_NUM_14, GPIO_NUM_13
+Note by T-vK: 
+              - pinD and pinA both need to have the same length
+              - if pinD[x] is equal to pinA[x] it is treated as a digital pin and the value of pinD[x] will be used, otherwise it will be treated as an analog pin and the value of pinA[x] will be used
+*/
+const byte pinD[] = {GPIO_NUM_12, GPIO_NUM_11, GPIO_NUM_10, GPIO_NUM_9, GPIO_NUM_8, GPIO_NUM_18, GPIO_NUM_17, GPIO_NUM_16, GPIO_NUM_15, GPIO_NUM_7, GPIO_NUM_6, GPIO_NUM_5, GPIO_NUM_38, GPIO_NUM_39};
+const byte pinA[] = {GPIO_NUM_12, GPIO_NUM_11, GPIO_NUM_10, GPIO_NUM_9, GPIO_NUM_8, GPIO_NUM_18, GPIO_NUM_17, GPIO_NUM_16, GPIO_NUM_15, GPIO_NUM_7, GPIO_NUM_6, GPIO_NUM_5, GPIO_NUM_14, GPIO_NUM_13};
+#define FACTORY_DEFAULT_PIN   GPIO_NUM_0    // Button BOOT
+#define DIN_MIDI_IN_PIN       GPIO_NUM_2
+#define DIN_MIDI_OUT_PIN      GPIO_NUM_1
+#define FASTLEDS_DATA_PIN     GPIO_NUM_42
+#undef  SDA
+#undef  SCL
+#define SDA                   GPIO_NUM_41
+#define SCL                   GPIO_NUM_40
 #else
 #undef  PEDALS
 #define PEDALS                7

--- a/src/PedalinoMini.cpp
+++ b/src/PedalinoMini.cpp
@@ -473,7 +473,7 @@ void setup()
 #ifdef WIFI
   if (wifiEnabled) {
     WiFi.persistent(false);
-#if defined(ARDUINO_BPI_LEAF_S3) || defined(ARDUINO_LILYGO_T_DISPLAY_S3)
+#if defined(ARDUINO_BPI_LEAF_S3) || defined(ARDUINO_LILYGO_T_DISPLAY_S3) || defined(ARDUINO_ESP32S3_DEV)
     WiFi.useStaticBuffers(true);
 #endif
     WiFi.onEvent(WiFiEvent);

--- a/src/USBMidiIn.h
+++ b/src/USBMidiIn.h
@@ -249,7 +249,7 @@ void usb_midi_connect()
   USB_MIDI.setHandleActiveSensing(OnUSBMidiActiveSensing);
   USB_MIDI.setHandleSystemReset(OnUSBMidiSystemReset);
 
-#if defined(ARDUINO_BPI_LEAF_S3) || defined(ARDUINO_LILYGO_T_DISPLAY_S3)
+#if defined(ARDUINO_BPI_LEAF_S3) || defined(ARDUINO_LILYGO_T_DISPLAY_S3) || defined(ARDUINO_ESP32S3_DEV)
   //usb_midi.setStringDescriptor("PedalinoMini USB MIDI");
   TinyUSBDevice.setManufacturerDescriptor("Pedalino");
   TinyUSBDevice.setProductDescriptor("PedalinoMini™");
@@ -258,7 +258,7 @@ void usb_midi_connect()
 
   // Initiate USB MIDI communications, listen to all channels
   USB_MIDI.begin(MIDI_CHANNEL_OMNI);
-#if defined(ARDUINO_BPI_LEAF_S3) || defined(ARDUINO_LILYGO_T_DISPLAY_S3)
+#if defined(ARDUINO_BPI_LEAF_S3) || defined(ARDUINO_LILYGO_T_DISPLAY_S3) || defined(ARDUINO_ESP32S3_DEV)
   // If already enumerated, additional class driverr begin() e.g msc, hid, midi won't take effect until re-enumeration
   if (TinyUSBDevice.mounted()) {
     TinyUSBDevice.detach();
@@ -269,7 +269,7 @@ void usb_midi_connect()
   // Enable/disable MIDI Thru
   interfaces[PED_USBMIDI].midiThru ? USB_MIDI.turnThruOn() : USB_MIDI.turnThruOff();
 
-#if defined(ARDUINO_BPI_LEAF_S3) || defined(ARDUINO_LILYGO_T_DISPLAY_S3)
+#if defined(ARDUINO_BPI_LEAF_S3) || defined(ARDUINO_LILYGO_T_DISPLAY_S3) || defined(ARDUINO_ESP32S3_DEV)
   // Wait until device mounted
   // while(!TinyUSBDevice.mounted()) delay(1);
 #endif

--- a/src/USBMidiOut.h
+++ b/src/USBMidiOut.h
@@ -11,7 +11,7 @@ __________           .___      .__  .__                 _____  .__       .__    
 
 #include <MIDI.h>
 
-#if defined(ARDUINO_BPI_LEAF_S3) || defined(ARDUINO_LILYGO_T_DISPLAY_S3)
+#if defined(ARDUINO_BPI_LEAF_S3) || defined(ARDUINO_LILYGO_T_DISPLAY_S3) || defined(ARDUINO_ESP32S3_DEV)
 
 #include <Adafruit_TinyUSB.h>
 

--- a/src/WifiConnect.h
+++ b/src/WifiConnect.h
@@ -521,7 +521,7 @@ bool wps_config()
 #endif
   wpsConfig.wps_type = WPS_TYPE_PBC;
   strcpy(wpsConfig.factory_info.manufacturer, "ESPRESSIF");
-#if defined(ARDUINO_BPI_LEAF_S3) || defined(ARDUINO_LILYGO_T_DISPLAY_S3)
+#if defined(ARDUINO_BPI_LEAF_S3) || defined(ARDUINO_LILYGO_T_DISPLAY_S3) || defined(ARDUINO_ESP32S3_DEV)
   strcpy(wpsConfig.factory_info.model_number, "ESP32-S3");
 #else
   strcpy(wpsConfig.factory_info.model_number, "ESP32");

--- a/src/partitions_esp32-s3-devkitc-1-n16r8v.csv
+++ b/src/partitions_esp32-s3-devkitc-1-n16r8v.csv
@@ -1,0 +1,8 @@
+# Name,   Type, SubType,  Offset,   Size,     Flags
+nvs0,     data, nvs,      0x9000,   0x5000,
+otadata,  data, ota,      0xE000,   0x2000,
+app0,     app,  ota_0,    0x10000,  0x360000,
+app1,     app,  ota_1,    0x370000, 0x360000,
+nvs,      data, nvs,      0x6D0000, 0x10000,
+spiffs,   data, spiffs,   0x6E0000, 0x110000,
+coredump, data, coredump, 0x7F0000, 0x10000,


### PR DESCRIPTION
I added support for a new board/build. You can now simply use an old Behringer FCB1010 and replace its ancient microcontroller, LEDs and display and with a modern ESP32-S3, an SSD1306 display and WS2812B LEDs. You could even add a battery or you just power it from USB-C. You'll get 12 foot switches and 2 expression pedals in a robust metal enclosure:

https://github.com/user-attachments/assets/4254c6cb-2792-49c5-a27a-6994bf151b2b



Technical details on the wiring:
![FCB-1010-MIDI-ESP32-S3_bb](https://github.com/user-attachments/assets/03bb4711-2b06-47d2-955e-89df3ef75570)


A lot of the original PCBs/traces of the FBC1010 can still be used!
The MIDI PCB for example has a simple 5V UART interface that can be connected directly to an Arduino (or through a bidirectional logic level converter to an ESP32-S3):
![image](https://github.com/user-attachments/assets/29cb927d-cfb7-46b8-83d5-95e1c8791691)
![image](https://github.com/user-attachments/assets/05b63685-7428-46dd-acff-ca8da1d9a62e)


The LEDs can simply be unsoldered and then you can glue in some WS2812B LEDs an use some of the original LED traces:
![image](https://github.com/user-attachments/assets/30aa0028-eab8-4a4a-9440-c3670a71e7ca)
![image](https://github.com/user-attachments/assets/0ec29ba4-1f51-49e7-a9e6-706cf102581f)

You can also directly get access to every single button from the pinouts of the LED/buttons PCB:
![image](https://github.com/user-attachments/assets/bf0e2211-424b-42cc-b622-39484fefb321)

